### PR TITLE
Take pending txs into consideration when assigning nonce

### DIFF
--- a/src/general_harvester.py
+++ b/src/general_harvester.py
@@ -544,7 +544,9 @@ class GeneralHarvester(IHarvester):
             dict: tx dictionary
         """
         options = {
-            "nonce": self.web3.eth.get_transaction_count(self.keeper_address),
+            "nonce": self.web3.eth.get_transaction_count(
+                self.keeper_address, "pending"
+            ),
             "from": self.keeper_address,
             "gas": GAS_LIMITS[self.chain],
         }


### PR DESCRIPTION
Should help in making sure two harvest txs don't get submitted with the same nonce. We might have to revert if we ever have to replace a tx that gets stuck due to low gas price